### PR TITLE
TMS-1021: Remove image carousel modal max-height

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1021: Remove image carousel modal max-height
+
 ## [1.2.2] - 2024-03-18
 
 - TMS-1017: Add image alt-text to imported news single-article

--- a/assets/styles/layouts/_image-carousel.scss
+++ b/assets/styles/layouts/_image-carousel.scss
@@ -12,7 +12,7 @@
             display: inline-block;
             overflow: hidden;
             max-width: 70vw;
-            
+
             img {
                 object-fit: contain;
                 clip-path: circle(closest-side);
@@ -40,7 +40,7 @@
 
         &.slick-arrow {
             background-color: transparent;
-            border:none;
+            border: none;
 
             .icon {
                 fill: $white;
@@ -64,7 +64,7 @@
                 right: 0;
             }
         }
-       
+
         .image-carousel__item {
             height: 80vh;
             display: flex !important;
@@ -77,33 +77,28 @@
                 width: auto;
             }
         }
-    
-        .img-wrapper{
-            flex:2 1 auto;
+
+        .img-wrapper {
+            flex: 2 1 auto;
             max-height: 100%;
-            height:auto;
+            height: auto;
             min-width: 0;
             min-height: 50%;
             display: flex;
             align-items: flex-end;
 
-            img{
+            img {
                 max-width: 100%;
-                max-height: 100% !important;
                 min-height: 100px;
                 object-fit: contain;
             }
         }
-    
+
         .image-block__meta {
-            flex:1 1 auto;
+            flex: 1 1 auto;
             width: 100%;
         }
-        
-
     }
-
-    
 }
 
 .slick-track .modal-trigger:focus {


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1021 Kuvakarusellin vaakakuvien asemointi
Task: https://hiondigital.atlassian.net/browse/TMS-1021

## Description
Remove max-height to prevent modal alignment problems with tms-theme-base fix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
