### PR TITLE
TMS-1107: Add caption-text to image-block meta

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1107: Add caption-text to image-block meta
+
 ## [1.3.3] - 2024-11-25
 
 - TMS-1059: Add Sign up-section to event partial

--- a/partials/ui/image/image-block__meta.dust
+++ b/partials/ui/image/image-block__meta.dust
@@ -1,7 +1,21 @@
 <div class="columns image-block__meta pt-2{?author_name} is-reversed{/author_name}">
     {?author_name}
         <div class="column is-2 has-text-right image-block__author-name has-text-small">
-            {author_name|s}.
+            {author_name|html}.
         </div>
     {/author_name}
+
+    {@isset key1=caption key2=image_title_and_artist method="OR" }
+        <div class="column keep-vertical-spacing image-block__caption">
+            {?image_title_and_artist}
+                <strong class="is-block">{image_title_and_artist|html}</strong>
+            {/image_title_and_artist}
+
+            {?caption}
+                <div class="keep-vertical-spacing">
+                    {caption|kses}
+                </div>
+            {/caption}
+        </div>
+    {/isset}
 </div>


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1107 Vapriikin kuvakarusellin "vapaaehtoiset kuvatekstit" eivät tule näkyviin
Task: https://hiondigital.atlassian.net/browse/TMS-1107

## Description

Add caption-text to image-block meta, which is used in image modals

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
