### PR TITLE
TMS-1260: Add sr-only text for opening image-blocks modal

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1260: Add sr-only text for opening image-blocks modal
+
 ## [1.6.1] - 2026-02-15
 
 - TMS-1164: Fix site header notice button hover

--- a/partials/blocks/block-image.dust
+++ b/partials/blocks/block-image.dust
@@ -1,11 +1,11 @@
 {?image}
-    <div {?anchor}id="{anchor}"{/anchor} class="image-block {wrapper_class}">
+    <div {?anchor}id="{anchor|attr}"{/anchor} class="image-block {wrapper_class|attr}">
         <div class="image">
             {>"shared/layout-before-main-content" /}
 
             {?is_clickable}
-                <a href="{image_url_orig}" class="has-modal is-block"
-                   {?image_caption}data-modaal-desc="{image_caption}"{/image_caption}>
+                <a href="{image_url_orig|url}" class="has-modal is-block"
+                   {?image_caption}data-modaal-desc="{image_caption|attr}"{/image_caption}>
                     <span class="is-sr-only">{open_large_image_string|html}</span>
                     {@image id=image.id size="large" alt=image.alt title=image.description /}
                 </a>

--- a/partials/blocks/block-image.dust
+++ b/partials/blocks/block-image.dust
@@ -6,6 +6,7 @@
             {?is_clickable}
                 <a href="{image_url_orig}" class="has-modal is-block"
                    {?image_caption}data-modaal-desc="{image_caption}"{/image_caption}>
+                    <span class="is-sr-only">{open_large_image_string|html}</span>
                     {@image id=image.id size="large" alt=image.alt title=image.description /}
                 </a>
             {:else}


### PR DESCRIPTION
Project: Tampereen kaupunki, konsernihallinto / Tietohallintoyksikkö:
Project task: Tampere multisite support

Task: https://hiondigital.atlassian.net/browse/TMS-1260
Task title: Saavutettavuus: Tampere Filharmonia, linkistä modaali-ikkunaan aukeavan kuvan tekstivastine

## Description
Add sr-only text for opening image-blocks modal

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
